### PR TITLE
Lyng 43 make elevenlabs spell out email addresses

### DIFF
--- a/vocode/streaming/agent/utils.py
+++ b/vocode/streaming/agent/utils.py
@@ -51,11 +51,8 @@ async def collate_response_async(
             # If the previous token didn't have leading whitespace and the current does:
             elif not prev_starts_with_whitespace and token_starts_with_whitespace:
                 # Assume last word in buffer is an email address
-                potential_email_text = buffer.split()[-1]
-                converted_email_text = convert_email_characters(potential_email_text)
-                # # If it was an email
-                # if converted_email_text != potential_email_text:
-                #     buffer = buffer.replace(potential_email_text, converted_email_text)
+                buffer = buffer.replace(buffer.split()[-1], convert_email_characters(buffer.split()[-1]))
+                # If sentence ends after potential email conversion:
                 if bool(re.findall(sentence_endings_pattern, buffer)):
                     yield buffer.strip()
                     buffer = ""
@@ -94,6 +91,7 @@ async def collate_response_async(
         
 def convert_email_characters(message: str):
     email_regex = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'
+    # If no email found, return input message.
     if not re.findall(email_regex, message):
         return message
     

--- a/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
+++ b/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
@@ -70,13 +70,15 @@ class ElevenLabsSynthesizer(BaseSynthesizer[ElevenLabsSynthesizerConfig]):
             converted_message = ""
             for char in message:
                 # Replace it if it exists in the dict. If not, make it upper case, surround in brackets, and seperate by commas.
-                converted_message += " [" + special_char_dict.get(char, char.upper()) + "],"
+                converted_message += " *" + special_char_dict.get(char, char.upper()) + "*."
             
             # Remove placed leading whitespace and trailing comma.
             converted_message = converted_message.removeprefix(" ").removesuffix(",")
             # If email had a trailing dot, add it back.
             if last_char_equals_dot:
                 converted_message += "."
+            
+            print(converted_message)
                     
             return converted_message
         

--- a/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
+++ b/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
@@ -85,7 +85,7 @@ class ElevenLabsSynthesizer(BaseSynthesizer[ElevenLabsSynthesizerConfig]):
                             '@' : " at "}
 
         # Split the message by whitespace to keep the structure
-        message_parts = re.split(r'(\s+)', message)     
+        message_parts = re.split(r'(\s+)', message)
 
         # This may be faster
         for email_part in emails:

--- a/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
+++ b/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
@@ -79,8 +79,8 @@ class ElevenLabsSynthesizer(BaseSynthesizer[ElevenLabsSynthesizerConfig]):
         email_regex = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'     
         emails = re.findall(email_regex, message)   
         
-        special_char_dict = {'-' : " dash ", 
-                            '_' : " underscore ", 
+        special_char_dict = {'-' : " dash ",
+                            '_' : " underscore ",
                             '.' : " dot ",
                             '@' : " at "}
 

--- a/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
+++ b/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
@@ -57,8 +57,6 @@ class ElevenLabsSynthesizer(BaseSynthesizer[ElevenLabsSynthesizerConfig]):
         bot_sentiment: Optional[BotSentiment] = None,
     ) -> SynthesisResult:
         
-        print("********ELEVENLABS*********")
-        
         # Initialize voice object
         voice = self.elevenlabs.Voice(voice_id=self.voice_id)
         
@@ -86,7 +84,7 @@ class ElevenLabsSynthesizer(BaseSynthesizer[ElevenLabsSynthesizerConfig]):
                             '.' : " dot ",
                             '@' : " at "}
 
-        # # Split the message by whitespace to keep the structure
+        # Split the message by whitespace to keep the structure
         message_parts = re.split(r'(\s+)', message)     
 
         # This may be faster
@@ -99,18 +97,8 @@ class ElevenLabsSynthesizer(BaseSynthesizer[ElevenLabsSynthesizerConfig]):
                 email_part = email_part.replace(character, special_char_dict.get(character))
             message_parts[message_index] = email_part
 
-        # for i, part in enumerate(message_parts):
-        #     if re.search(email_regex, part) is not None:
-        #         for character in special_char_dict:
-        #             part = part.replace(character, special_char_dict.get(character))
-        #         message_parts[i] = part
-        
-        # Simple but might be super slow:
-        # for character in special_char_dict:
-        #     message = message.replace(character, special_char_dict.get(character))
-
         message = "".join(message_parts)
-
+                            
         # Prepare request headers
         headers = {"xi-api-key": self.api_key}
         

--- a/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
+++ b/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
@@ -74,28 +74,6 @@ class ElevenLabsSynthesizer(BaseSynthesizer[ElevenLabsSynthesizerConfig]):
 
         if self.optimize_streaming_latency:
             url += f"?optimize_streaming_latency={self.optimize_streaming_latency}"
-            
-        # # Perform email checks on the message text
-        # email_regex = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'     
-        # emails = re.findall(email_regex, message)   
-        
-        # special_char_dict = {'-' : " dash ",
-        #                     '_' : " underscore ",
-        #                     '.' : " dot ",
-        #                     '@' : " at "}
-
-        # # Split the message by whitespace to keep the structure
-        # message_parts = re.split(r'(\s+)', message)
-
-        # # This may be faster
-        # for email_part in emails:
-        #     try: 
-        #         message_index = message_parts.index(email_part)
-        #     except Exception: 
-        #         continue
-        #     for character in special_char_dict:
-        #         email_part = email_part.replace(character, special_char_dict.get(character))
-        #     message_parts[message_index] = email_part
 
         email_regex = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'   
 
@@ -119,8 +97,6 @@ class ElevenLabsSynthesizer(BaseSynthesizer[ElevenLabsSynthesizerConfig]):
             if re.match(email_regex, part) is not None:
                 message_parts[i] = email_text_convert(message_parts[i])
         message.text = "".join(message_parts)
-        
-        print("********", message, "**********")
                             
         # Prepare request headers
         headers = {"xi-api-key": self.api_key}
@@ -155,7 +131,6 @@ class ElevenLabsSynthesizer(BaseSynthesizer[ElevenLabsSynthesizerConfig]):
         
         # If experimental streaming is enabled, return streaming synthesis result
         if self.experimental_streaming:
-            print("***IF***")
             return SynthesisResult(
                 self.experimental_mp3_streaming_output_generator(
                     response, chunk_size, create_speech_span
@@ -167,7 +142,6 @@ class ElevenLabsSynthesizer(BaseSynthesizer[ElevenLabsSynthesizerConfig]):
             
         # If not experimental streaming, read audio data and process it
         else:
-            print("***ELSE CODE***")
             audio_data = await response.read()
             create_speech_span.end()
             

--- a/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
+++ b/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
@@ -75,29 +75,52 @@ class ElevenLabsSynthesizer(BaseSynthesizer[ElevenLabsSynthesizerConfig]):
         if self.optimize_streaming_latency:
             url += f"?optimize_streaming_latency={self.optimize_streaming_latency}"
             
-        # Perform email checks on the message text
-        email_regex = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'     
-        emails = re.findall(email_regex, message)   
+        # # Perform email checks on the message text
+        # email_regex = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'     
+        # emails = re.findall(email_regex, message)   
         
-        special_char_dict = {'-' : " dash ",
-                            '_' : " underscore ",
-                            '.' : " dot ",
-                            '@' : " at "}
+        # special_char_dict = {'-' : " dash ",
+        #                     '_' : " underscore ",
+        #                     '.' : " dot ",
+        #                     '@' : " at "}
 
-        # Split the message by whitespace to keep the structure
-        message_parts = re.split(r'(\s+)', message)
+        # # Split the message by whitespace to keep the structure
+        # message_parts = re.split(r'(\s+)', message)
 
-        # This may be faster
-        for email_part in emails:
-            try: 
-                message_index = message_parts.index(email_part)
-            except Exception: 
-                continue
-            for character in special_char_dict:
-                email_part = email_part.replace(character, special_char_dict.get(character))
-            message_parts[message_index] = email_part
+        # # This may be faster
+        # for email_part in emails:
+        #     try: 
+        #         message_index = message_parts.index(email_part)
+        #     except Exception: 
+        #         continue
+        #     for character in special_char_dict:
+        #         email_part = email_part.replace(character, special_char_dict.get(character))
+        #     message_parts[message_index] = email_part
 
-        message = "".join(message_parts)
+        email_regex = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'   
+
+        # # Split the message by whitespace to keep the structure
+        message_parts = re.split(r'(\s+)', message.text)                   
+        # message_parts = message.text.split()
+
+        def email_text_convert(message):
+            special_char_dict = {'-' : " dash ", 
+                                '_' : " underscore ", 
+                                '.' : " dot ",
+                                '@' : " at "}
+            
+            converted_message = ""
+            for char in message:
+                converted_message += special_char_dict.get(char, char)
+            
+            return converted_message
+
+        for i, part in enumerate(message_parts):
+            if re.match(email_regex, part) is not None:
+                message_parts[i] = email_text_convert(message_parts[i])
+        message.text = "".join(message_parts)
+        
+        print("********", message, "**********")
                             
         # Prepare request headers
         headers = {"xi-api-key": self.api_key}

--- a/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
+++ b/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
@@ -91,7 +91,10 @@ class ElevenLabsSynthesizer(BaseSynthesizer[ElevenLabsSynthesizerConfig]):
 
         # This may be faster
         for email_part in emails:
-            message_index = message_parts.index(email_part)
+            try: 
+                message_index = message_parts.index(email_part)
+            except Exception: 
+                continue
             for character in special_char_dict:
                 email_part = email_part.replace(character, special_char_dict.get(character))
             message_parts[message_index] = email_part


### PR DESCRIPTION
Utils.py - collate_response(): changed to avoid yielding partial email addresses within messages.
eleven_labs_synthesizer - create_speech(): searches messages for email addresses and spells them out for synthesizer output without propagating change into program.

*** Deny changes in azure_synthesizer.py - redundant code and comments ***